### PR TITLE
Add copy image to clipboard functionality

### DIFF
--- a/src/components/BingoCard.css
+++ b/src/components/BingoCard.css
@@ -4,6 +4,7 @@
   align-items: center;
   margin: auto;
 }
+
 .bingo-card {
   display: grid;
   grid-template-rows: repeat(3, 1fr);
@@ -74,4 +75,19 @@
     width: auto; /* Adjust width */
     margin: 20px;
   }
+}
+
+.error-message {
+  margin-top: 2rem;
+  color: red;
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+.dismiss-button {
+  border: 0;
+  background-color: transparent;
+  cursor: pointer;
+  vertical-align: top;
+  font-weight: bold;
 }

--- a/src/components/BingoCard.tsx
+++ b/src/components/BingoCard.tsx
@@ -19,10 +19,8 @@ const BingoCard = ({ card, cardIndex, onCardDeselect }: BingoCardProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const ref = useRef(null);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [image, takeScreenShot] = useScreenshot({
-    type: "image/jpeg",
-    quality: 1.0
-  });
+  const [image, takeScreenShot] = useScreenshot();
+  const [error, setError] = useState<string>();
 
   const { load, save } = useSave({ cardId: cardIndex, saveId: 0, });
 
@@ -119,6 +117,12 @@ const BingoCard = ({ card, cardIndex, onCardDeselect }: BingoCardProps) => {
         {/*<button onClick={onCardDeselect}>Pick another card</button>*/
         }
       </div>
+      {error ?
+        <div className="error-message">
+          <span>{error}</span>
+          <input type="button" className="dismiss-button" onClick={() => setError('')} value="X" />
+        </div>
+      : null}
     </div>
   );
 };

--- a/src/components/BingoCard.tsx
+++ b/src/components/BingoCard.tsx
@@ -71,6 +71,21 @@ const BingoCard = ({ card, cardIndex, onCardDeselect }: BingoCardProps) => {
   //Takes a screenshot of the card and downloads it
   const downloadScreenshot = () => takeScreenShot(ref.current).then(download);
 
+  const copyScreenshot = async () => {
+    try {
+      const screenshotURI = await takeScreenShot(ref.current);
+      // Converts URI data string to a blob
+      const blob = await ((await fetch(screenshotURI)).blob());
+      if (ClipboardItem.supports("image/png")) {
+        const data = [new ClipboardItem({ 'image/png': blob })];
+        navigator.clipboard.write(data);
+        console.log('copied png blob to clipboard!');
+      }
+    } catch (e) {
+      setError("Error copying to clipboard.");
+    }
+  }
+
   return (
     <div>
       <div className="bingo-card-wrapper">
@@ -100,6 +115,7 @@ const BingoCard = ({ card, cardIndex, onCardDeselect }: BingoCardProps) => {
       <div className="bingo-buttons">
         <button onClick={clearCard}>Clear card</button>
         <button onClick={downloadScreenshot}>Download card image</button>
+        <button onClick={copyScreenshot}>Copy card image</button>
         {/*<button onClick={onCardDeselect}>Pick another card</button>*/
         }
       </div>


### PR DESCRIPTION
Add a button that takes a screenshot and copies it to clipboard (as opposed to downloading it as a file).

New button:
![image](https://github.com/user-attachments/assets/31b7b42b-e6a5-4126-a427-2cbb31b3549b)

Example result pasted from clipboard:
![image](https://github.com/user-attachments/assets/c3793b2d-2053-4c9c-a34d-9f9910349a99)

Also added an error message below the buttons in case the copy fails.