### PR TITLE
Indicate which card has been saved

### DIFF
--- a/src/components/CardSelection.css
+++ b/src/components/CardSelection.css
@@ -26,3 +26,8 @@
     border-radius: 0.9rem;
     cursor: pointer;
 }
+
+.has-save {
+    text-decoration: underline;
+    font-weight: 600;
+}

--- a/src/components/CardSelection.tsx
+++ b/src/components/CardSelection.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import "./CardSelection.css";
+import { useSave } from "../hooks/useSave";
 
 export interface CardSelectionProps {
   onCardSelect: (cardIndex: number) => void;
@@ -9,12 +10,22 @@ export interface CardSelectionProps {
 const cardIndexes = [...Array(61).keys()].slice(1);
 
 function CardSelection({ onCardSelect }: CardSelectionProps) {
+  const [saves, setSaves] = useState<Array<string>>();
+
+  useEffect(() => {
+    const saves = Object.keys(localStorage).map((k) => k.split('-')[0]);
+    console.log(saves);
+    setSaves(saves);
+  }, []);
+
   return (
     <div className="card-selection">
       <p className="card-selection-title">Please select a bingo card!</p>
       <div className="selection-container">
         {cardIndexes.map((n) => 
-          (<input className="card-select" type="button" key={n}
+          (<input
+            type="button" key={n}
+            className={`card-select${saves?.includes(n.toString()) ? ' has-save' : ''}`}
             value={n} onClick={(e) => onCardSelect(parseInt((e.target as HTMLInputElement).value))}
           />)
         )}

--- a/src/components/CardSelection.tsx
+++ b/src/components/CardSelection.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 
 import "./CardSelection.css";
-import { useSave } from "../hooks/useSave";
 
 export interface CardSelectionProps {
   onCardSelect: (cardIndex: number) => void;


### PR DESCRIPTION
A user might find themselves in the card selection screen and not remember which card they have been playing with.
Being able to indicate which cards have saves can help user find their card.

Example card selection screen with multiple saved cards:
![image](https://github.com/user-attachments/assets/9b40e437-b083-4714-955f-408f3c9ff290)
