### PR TITLE
Card selection is spilling horizontally

### DIFF
--- a/src/components/CardSelection.css
+++ b/src/components/CardSelection.css
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    overflow: auto;
 }
 
 .card-selection-title {
@@ -35,5 +36,11 @@
 @media only screen and (max-width: 550px) {
     .selection-container {
         grid-template-columns: repeat(5, auto);
+    }
+}
+
+@media only screen and (max-width: 250px) {
+    .selection-container {
+        grid-template-columns: repeat(2, auto);
     }
 }


### PR DESCRIPTION
Bug screenshot:
![image](https://github.com/user-attachments/assets/c6a29234-0503-4a3e-85e0-adc7e30f6b19)

Proposed fix:
Add a breakpoint (at 550px) that changes the number of cards per row to 5 and another one (at 250px) to limit it down to 2 per row.

Solution screenshot (overflow enabled):
![image](https://github.com/user-attachments/assets/2e801742-7b1a-4579-a2f2-466a4a709d90)
