### PR TITLE
Safari errors when using `ClipboardItem.supports()`

### DIFF
--- a/src/components/BingoCard.tsx
+++ b/src/components/BingoCard.tsx
@@ -74,10 +74,10 @@ const BingoCard = ({ card, cardIndex, onCardDeselect }: BingoCardProps) => {
       const screenshotURI = await takeScreenShot(ref.current);
       // Converts URI data string to a blob
       const blob = await ((await fetch(screenshotURI)).blob());
-      if (ClipboardItem.supports("image/png")) {
+      // NOTE: Safari doesn't support ClipboardItem.supports()
+      if (ClipboardItem?.supports("image/png") !== false) {
         const data = [new ClipboardItem({ 'image/png': blob })];
         navigator.clipboard.write(data);
-        //console.log('copied png blob to clipboard!');
       }
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
Apparently safari doesn't support `ClipboardItem.supports()`. So I added a null propagation and only error on it returning false.

https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/supports_static